### PR TITLE
extended functionality of hansen_neurotransmitter_maps()

### DIFF
--- a/CanlabCore/@image_vector/hansen_neurotransmitter_maps.m
+++ b/CanlabCore/@image_vector/hansen_neurotransmitter_maps.m
@@ -30,7 +30,17 @@ function [stats, ntmaps, hh, hhfill, table_group, multcomp_group] = hansen_neuro
 %        image_similarity_plot)
 %   
 %    **doAverage:**
-%      Plot average correlation from the input images
+%        Plot average correlation from the input images, over all subjects
+%        or per group in case 'comparGroups' is specified
+%
+%    **compareGroups**
+%        Perform multiple one-way ANOVAs with group as a factor (one for
+%        each spatial basis); requires group as subsequent input
+%
+%    **group**
+%        Indicates group membership for each image as vector, categorical,
+%        or string array
+%
 % :Outputs:
 %
 %   **stats:**
@@ -113,6 +123,11 @@ function [stats, ntmaps, hh, hhfill, table_group, multcomp_group] = hansen_neuro
 %    Ke:Add function to input group of image_obj and plot mean correlation.
 %    e.g group of bootsrap sample. In this case, the error bar is displayed
 %    by standard deviation.
+%
+%    Lukas: Added group/ANOVA functionality from image_similarity_plot to
+%    this function, and debugged plotting for multiple groups in
+%    image_similarity_plot
+%
 % ..
 
 % -------------------------------------------------------------------------
@@ -135,7 +150,7 @@ doAverage=0;
 
 allowable_inputs = {'colors' 'doplot' 'similarity_metric' 'dofixrange'};
 
-keyword_inputs = {'noplot' 'nofigure' 'cosine_similarity','doAverage'};
+keyword_inputs = {'noplot' 'nofigure' 'cosine_similarity' 'doAverage' 'compareGroups'};
 
 % optional inputs with default values - each keyword entered will create a variable of the same name
 
@@ -168,8 +183,13 @@ for i = 1:length(varargin)
 
             case 'cosine_similarity'
                 similarity_metric = 'cosine_similarity';
+                
             case 'doAverage'
                 doAverage=1;
+                
+            case 'compareGroups'
+                compareGroups = true;
+                group = varargin{i+1};
 
         end
     end
@@ -198,11 +218,29 @@ if doplot
 
     if doAverage==1
         if isempty(dofixrange)
-             [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'average','Error_STD');
+            
+            if exist('compareGroups','var') % added by Lukas: if we want to analyze & plot multiple groups 
+                
+                [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'average','compareGroups', group);
+           
+            else
+                
+                [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'average','Error_STD');
+            end
+            
         else
+            
+            if exist('compareGroups','var') % % added by Lukas: if we want to analyze & plot multiple groups 
+                
+                [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'dofixrange', dofixrange, 'average', 'compareGroups', group);
 
-              [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'dofixrange', dofixrange,'average','Error_STD');
+            else
+                
+                [stats, hh, hhfill, table_group, multcomp_group] = image_similarity_plot(fmri_data_obj, 'mapset', ntmaps, similarity_metric, 'plotstyle', 'polar', 'networknames', ntmaps.metadata_table.target, 'colors', colors, 'nofigure', 'dofixrange', dofixrange,'average','Error_STD');
+            end
+            
         end
+        
     else
         if isempty(dofixrange)
     

--- a/CanlabCore/Visualization_functions/tor_wedge_plot.m
+++ b/CanlabCore/Visualization_functions/tor_wedge_plot.m
@@ -183,7 +183,7 @@ end
     
 % Error checks
 
-if any(size(outer_circle_radius)) > 1, error('''outer_circle_radius'' input should be followed by a scalar value.'); end
+if any(size(outer_circle_radius) > 1), error('''outer_circle_radius'' input should be followed by a scalar value.'); end % Lukas corrected syntax error causing the check to always return false
 
 
 % --------------------------------------------------------------------------


### PR DESCRIPTION
Hi @torwager @Michael-Sun @KeBo2018 

I extended the functionality of the very nice hansen_neurotransmitter_maps() function to include group comparisons, using the 'average' and 'compareGroups' options of the image_similarity_plot() function called by it (which @Michael-Sun and @KeBo2018 recently improved).

The polarplot and wedgeplot code (calling tor_polar_plot() and tor_wedge_plot() under the hood, respectively) for plotting group comparisons correctly needed quite a bit of debugging, which I did and tested fairly extensively.

Please have a look, do any further testing if you like, and then pull the improvements into the master branch if you like them.

Thanks and cheers,

Lukas